### PR TITLE
Potential fix for code scanning alert no. 13: Incorrect conversion between integer types

### DIFF
--- a/internal/socks/socks.go
+++ b/internal/socks/socks.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"math/big"
+	"math"
 	"net"
 	"sync/atomic"
 	"time"
@@ -69,7 +70,11 @@ func Start(ctx context.Context, insts []*config.Instance, cfg *config.Config) {
 			instRotateSecs[idx] = int64(cfg.ParanoidRotateSeconds)
 		} else {
 			instTier[idx] = 0
-			instMaxConns[idx] = int32(cfg.StableMaxConnsPerInstance)
+			stableMax := cfg.StableMaxConnsPerInstance
+			if stableMax > math.MaxInt32 {
+				stableMax = math.MaxInt32
+			}
+			instMaxConns[idx] = int32(stableMax)
 			instRotateConns[idx] = uint64(cfg.StableRotateConns)
 			instRotateSecs[idx] = int64(cfg.StableRotateSeconds) // ≤ 1 hour, enforced in config
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/myhme/torgo/security/code-scanning/13](https://github.com/myhme/torgo/security/code-scanning/13)

The best fix is to ensure that before converting from the config field (`cfg.StableMaxConnsPerInstance`, type `int`) to `int32`, we check that the value does not exceed `math.MaxInt32`. This guarantees future maintainers don't accidentally allow overflows if the input bounds change. Add a check at the conversion site (internal/socks/socks.go:72), using a conditional:  
```go
if cfg.StableMaxConnsPerInstance > math.MaxInt32 { ... }
```
If the value is too high, set it to a safe default (e.g. `math.MaxInt32`).  
You will need to import `"math"` in internal/socks/socks.go to reference `math.MaxInt32`.  
Edit the code to check and clamp the value before conversion in both the "stable" and "paranoid" branches if needed (but CodeQL only highlighted the stable branch for now). The replacement should minimally edit the original code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
